### PR TITLE
Fix docker-compose port mapping for host-level SSL termination

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,6 @@ services:
       dockerfile: Dockerfile
     restart: always
     ports:
-      - "80:80"
+      - "3000:80"
     depends_on:
       - backend


### PR DESCRIPTION
Host nginx handles SSL termination on 443 and proxies to port 3000. Frontend container must bind to 3000:80, not 80:80, to avoid port conflicts with the host nginx process.